### PR TITLE
Add tests for provider with arguments

### DIFF
--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module backend.framework.core {
     exports io.john.amiscaray.backend.framework.core.properties;
     exports io.john.amiscaray.backend.framework.core;
+    exports io.john.amiscaray.backend.framework.core.di.exception;
     exports io.john.amiscaray.backend.framework.core.di.provider;
     exports io.john.amiscaray.backend.framework.core.di;
     requires lombok;

--- a/core/src/test/java/io/john/amiscaray/backend/framework/core/di/ApplicationContextTest.java
+++ b/core/src/test/java/io/john/amiscaray/backend/framework/core/di/ApplicationContextTest.java
@@ -52,6 +52,24 @@ public class ApplicationContextTest {
     }
 
     @Test
+    public void testProvideGreeting() {
+
+        assertEquals(stringProvider.greeting(
+                stringProvider.username(),
+                stringProvider.accountName(),
+                userAccountProvider.userAccount().balance()
+        ), ctx.getInstance(new Dependency<>("greeting", String.class)));
+
+    }
+
+    @Test
+    public void testProvideAccountString() {
+
+        assertEquals(userAccountProvider.userAccount().toString(), ctx.getInstance(new Dependency<>("accountString", String.class)));
+
+    }
+
+    @Test
     public void testProvideMockUser() {
 
         assertEquals(userProvider.getUser(), ctx.getInstance(MockUser.class));

--- a/core/src/test/java/io/john/amiscaray/backend/framework/core/di/stub/MockStringProvider.java
+++ b/core/src/test/java/io/john/amiscaray/backend/framework/core/di/stub/MockStringProvider.java
@@ -1,7 +1,9 @@
 package io.john.amiscaray.backend.framework.core.di.stub;
 
 import io.john.amiscaray.backend.framework.core.di.provider.Provide;
+import io.john.amiscaray.backend.framework.core.di.provider.ProvidedWith;
 import io.john.amiscaray.backend.framework.core.di.provider.Provider;
+import io.john.amiscaray.backend.framework.core.di.stub.pojo.MockUserAccount;
 
 @Provider
 public class MockStringProvider {
@@ -14,6 +16,19 @@ public class MockStringProvider {
     @Provide(dependencyName = "accountName")
     public String accountName() {
         return "Savings";
+    }
+
+    @Provide(dependencyName = "greeting")
+    public String greeting(
+            @ProvidedWith(dependencyName = "username") String username,
+            @ProvidedWith(dependencyName = "accountName") String accountName,
+            @ProvidedWith(dependencyName = "balance") Long balance) {
+        return String.format("Hello %s! This is your %s account with balance: $%s", username, accountName, balance);
+    }
+
+    @Provide(dependencyName = "accountString")
+    public String accountString(MockUserAccount userAccount) {
+        return userAccount.toString();
     }
 
 }


### PR DESCRIPTION
Providers already inherently have this functionality, unintentionally. This ticket just adds tests that establish this contract.