### PR TITLE
Implement Bug Fixes For Generator API

### DIFF
--- a/api-generator/src/main/java/io/john/amiscaray/quak/generator/ApiGeneratorMojo.java
+++ b/api-generator/src/main/java/io/john/amiscaray/quak/generator/ApiGeneratorMojo.java
@@ -37,7 +37,7 @@ public class ApiGeneratorMojo extends AbstractMojo {
     private File generatedClassesDirectory;
 
     @Parameter(required = true)
-    private String targetPackage;
+    private String targetControllerPackage;
 
     @Parameter(required = true)
     private String rootPackage;
@@ -79,7 +79,7 @@ public class ApiGeneratorMojo extends AbstractMojo {
     }
 
     private void generateModuleInfo() {
-        var moduleInfoWriter = new ModuleInfoWriter(visitedSourcesState, rootPackage, moduleInfoTemplateSource);
+        var moduleInfoWriter = new ModuleInfoWriter(visitedSourcesState, rootPackage, targetControllerPackage, moduleInfoTemplateSource);
         try {
             writeGeneratedModuleInfo(moduleInfoWriter.writeModuleInfo());
         } catch (IOException e) {
@@ -115,7 +115,7 @@ public class ApiGeneratorMojo extends AbstractMojo {
         }
 
         for (var restModelToEntityClassEntry : restModelClassToEntityClass.entrySet()) {
-            var generatedSource = controllerWriter.writeNewController(targetPackage, restModelToEntityClassEntry.getKey(), restModelToEntityClassEntry.getValue());
+            var generatedSource = controllerWriter.writeNewController(targetControllerPackage, restModelToEntityClassEntry.getKey(), restModelToEntityClassEntry.getValue());
             try {
                 writeGeneratedController(generatedSource);
             } catch (IOException e) {
@@ -125,7 +125,7 @@ public class ApiGeneratorMojo extends AbstractMojo {
     }
 
     private void writeGeneratedController(GeneratedClass generatedClass) throws IOException {
-        var packageSubFolders = targetPackage.replace(".", "/");
+        var packageSubFolders = targetControllerPackage.replace(".", "/");
         var outDirectory = new File(generatedClassesDirectory, "/" + packageSubFolders);
         if (!outDirectory.exists()) {
             outDirectory.mkdirs();

--- a/api-generator/src/main/java/io/john/amiscaray/quak/generator/jpms/ModuleInfoWriter.java
+++ b/api-generator/src/main/java/io/john/amiscaray/quak/generator/jpms/ModuleInfoWriter.java
@@ -4,41 +4,74 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import io.john.amiscaray.quak.generator.model.VisitedSourcesState;
 import lombok.AllArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @AllArgsConstructor
 public class ModuleInfoWriter {
 
     private VisitedSourcesState finalVisitedSourcesState;
     private String rootPackage;
+    private String targetControllerPackage;
     private String moduleInfoTemplate;
-
-    public ModuleInfoWriter(VisitedSourcesState finalVisitedSourcesState, String rootPackage) {
-        this.finalVisitedSourcesState = finalVisitedSourcesState;
-        this.rootPackage = rootPackage;
-    }
 
     public String writeModuleInfo() {
         if (finalVisitedSourcesState.visitedRestModelClasses().isEmpty() && finalVisitedSourcesState.visitedEntityClasses().isEmpty()) {
             return null;
         }
 
-        var modelPackages = extractPackagesFromClasses(finalVisitedSourcesState.visitedRestModelClasses());
+        var packageNameToPackageInfo = new HashMap<String, ParsedPackageInfo>();
+
+        var restModelPackages = extractPackagesFromClasses(finalVisitedSourcesState.visitedRestModelClasses());
+        for (var restModelPackage : restModelPackages) {
+            if (packageNameToPackageInfo.containsKey(restModelPackage)) {
+                packageNameToPackageInfo.get(restModelPackage)
+                        .setContainsRestModelClasses(true);
+            } else {
+                packageNameToPackageInfo.put(
+                        restModelPackage,
+                        new ParsedPackageInfo(restModelPackage, false, true, false));
+            }
+        }
         var ormPackages = extractPackagesFromClasses(finalVisitedSourcesState.visitedEntityClasses());
+        for (var ormPackage : ormPackages) {
+            if (packageNameToPackageInfo.containsKey(ormPackage)) {
+                packageNameToPackageInfo.get(ormPackage)
+                        .setContainsORMClasses(true);
+            } else {
+                packageNameToPackageInfo.put(
+                        ormPackage,
+                        new ParsedPackageInfo(ormPackage, true, false, false)
+                );
+            }
+        }
         var diComponentPackages = extractPackagesFromClasses(finalVisitedSourcesState.visitedDIComponents());
+        for (var diComponentPackage : diComponentPackages) {
+            if (packageNameToPackageInfo.containsKey(diComponentPackage)) {
+                packageNameToPackageInfo.get(diComponentPackage)
+                        .setContainsDIClasses(true);
+            } else {
+                packageNameToPackageInfo.put(
+                        diComponentPackage,
+                        new ParsedPackageInfo(diComponentPackage, false, false, true)
+                );
+            }
+        }
 
         if (moduleInfoTemplate == null) {
             return String.format("""
             module %1$s {
             %2$s
             }
-            """, rootPackage, generateModuleInfoContent(modelPackages, ormPackages, diComponentPackages));
+            """, rootPackage, generateModuleInfoContent(packageNameToPackageInfo));
         } else {
             // remove the closing curly bracket and add some space to add the generated code
             moduleInfoTemplate = moduleInfoTemplate.stripTrailing();
             moduleInfoTemplate = moduleInfoTemplate.substring(0, moduleInfoTemplate.length() - 1) + "\n    // GENERATED SOURCES:\n";
 
-            return moduleInfoTemplate + generateModuleInfoContent(modelPackages, ormPackages, diComponentPackages) + "}";
+            return moduleInfoTemplate + generateModuleInfoContent(packageNameToPackageInfo) + "}";
         }
     }
 
@@ -52,16 +85,11 @@ public class ModuleInfoWriter {
                 .toList();
     }
 
-    private String generateModuleInfoContent(List<String> modelPackages, List<String> ormPackages, List<String> diComponentPackages) {
+    private String generateModuleInfoContent(Map<String, ParsedPackageInfo> packageNameToPackageInfo) {
         return String.format("""
-                exports %1$s.controllers to quak.framework.core, quak.framework.web;
+                exports %1$s to quak.framework.core, quak.framework.web;
                 
-                // Rules for RestModels
                 %2$s
-                // Rules for Entities
-                %3$s
-                // Rules for DI Components
-                %4$s
                 
                 requires quak.framework.core;
                 requires quak.framework.data;
@@ -71,10 +99,32 @@ public class ModuleInfoWriter {
                 requires jakarta.persistence;
                 requires static lombok;
                 requires org.reflections;
-                """, rootPackage, generateRulesForModelPackages(modelPackages),
-                        generateRulesForORMPackages(ormPackages),
-                        generateRulesForPackagesWithDIComponents(diComponentPackages))
-                .indent(4);
+                """, targetControllerPackage,
+                generateRulesForPackages(packageNameToPackageInfo)).indent(4);
+    }
+
+    private String generateRulesForPackages(Map<String, ParsedPackageInfo> packageNameToPackageInfo) {
+        var resultingRules = new StringBuilder();
+        for (var packageInfo : packageNameToPackageInfo.values()) {
+            resultingRules.append(generateRulesForPackage(packageInfo));
+            resultingRules.append("\n");
+        }
+        return resultingRules.toString().stripTrailing();
+    }
+
+    private String generateRulesForPackage(ParsedPackageInfo packageInfo) {
+        var resultingRule = new StringBuilder("opens ").append(packageInfo.getPackageName()).append(" to ");
+        var openedTo = new ArrayList<String>();
+        if (packageInfo.isContainsDIClasses()) {
+            openedTo.add("quak.framework.core");
+        }
+        if (packageInfo.isContainsRestModelClasses()) {
+            openedTo.add("com.fasterxml.jackson.databind");
+        }
+        if (packageInfo.isContainsORMClasses()) {
+            openedTo.add("org.hibernate.orm.core");
+        }
+        return resultingRule.append(String.join(", ", openedTo)).append(";").toString();
     }
 
     private String generateRulesForModelPackages(List<String> modelPackages) {

--- a/api-generator/src/main/java/io/john/amiscaray/quak/generator/jpms/ParsedPackageInfo.java
+++ b/api-generator/src/main/java/io/john/amiscaray/quak/generator/jpms/ParsedPackageInfo.java
@@ -1,0 +1,17 @@
+package io.john.amiscaray.quak.generator.jpms;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class ParsedPackageInfo {
+
+    private String packageName;
+    private boolean containsORMClasses;
+    private boolean containsRestModelClasses;
+    private boolean containsDIClasses;
+
+}

--- a/api-generator/src/test/java/io/john/amiscaray/quak/generator/test/jpms/ModuleInfoWriterTest.java
+++ b/api-generator/src/test/java/io/john/amiscaray/quak/generator/test/jpms/ModuleInfoWriterTest.java
@@ -31,24 +31,23 @@ public class ModuleInfoWriterTest {
     public void testWritesModuleInfoForStudentAndEmployeeStubs() {
         var moduleInfoWriter = new ModuleInfoWriter(
                 mockFinalVisitedSourcesStatue(),
-                "io.john.amiscaray"
+                "io.john.amiscaray",
+                "io.john.amiscaray.controllers",
+                null
+
         );
 
         assertThat(
                 moduleInfoWriter.writeModuleInfo(),
                 equalToCompressingWhiteSpace("""
                 module io.john.amiscaray {
-                
                     exports io.john.amiscaray.controllers to quak.framework.core, quak.framework.web;
-                    
-                    // Rules for RestModels
+                   \s
                     opens io.john.amiscaray.stub.model to com.fasterxml.jackson.databind;
-                    // Rules for Entities
-                    opens io.john.amiscaray.stub.data to org.hibernate.orm.core;
-                    // Rules for DI Components
-                    opens io.john.amiscaray.domain to quak.framework.core;
                     opens io.john.amiscaray.quak.data.di to quak.framework.core;
-                    
+                    opens io.john.amiscaray.domain to quak.framework.core;
+                    opens io.john.amiscaray.stub.data to org.hibernate.orm.core;
+                   \s
                     requires quak.framework.core;
                     requires quak.framework.data;
                     requires quak.framework.generator.model;
@@ -57,7 +56,42 @@ public class ModuleInfoWriterTest {
                     requires jakarta.persistence;
                     requires static lombok;
                     requires org.reflections;
-                
+
+                }
+                """)
+        );
+    }
+
+    @Test
+    public void testWritesModuleInfoForStudentAndEmployeeStubsWithTargetControllerPackageSameAsRootPackage() {
+        var moduleInfoWriter = new ModuleInfoWriter(
+                mockFinalVisitedSourcesStatue(),
+                "io.john.amiscaray",
+                "io.john.amiscaray",
+                null
+
+        );
+
+        assertThat(
+                moduleInfoWriter.writeModuleInfo(),
+                equalToCompressingWhiteSpace("""
+                module io.john.amiscaray {
+                    exports io.john.amiscaray to quak.framework.core, quak.framework.web;
+                   \s
+                    opens io.john.amiscaray.stub.model to com.fasterxml.jackson.databind;
+                    opens io.john.amiscaray.quak.data.di to quak.framework.core;
+                    opens io.john.amiscaray.domain to quak.framework.core;
+                    opens io.john.amiscaray.stub.data to org.hibernate.orm.core;
+                   \s
+                    requires quak.framework.core;
+                    requires quak.framework.data;
+                    requires quak.framework.generator.model;
+                    requires quak.framework.web;
+                    requires quak.framework.web.model;
+                    requires jakarta.persistence;
+                    requires static lombok;
+                    requires org.reflections;
+
                 }
                 """)
         );
@@ -68,6 +102,7 @@ public class ModuleInfoWriterTest {
         var moduleInfoWriter = new ModuleInfoWriter(
                 mockFinalVisitedSourcesStatue(),
                 "io.john.amiscaray",
+                "io.john.amiscaray.http",
                 """
                         module my.module {
                         
@@ -82,26 +117,24 @@ public class ModuleInfoWriterTest {
                 equalToCompressingWhiteSpace("""
                         module my.module {
                         
-                            requires org.slf4j;
-                            // GENERATED SOURCES:
-                            exports io.john.amiscaray.controllers to quak.framework.core, quak.framework.web;
-                    
-                            // Rules for RestModels
-                            opens io.john.amiscaray.stub.model to com.fasterxml.jackson.databind;
-                            // Rules for Entities
-                            opens io.john.amiscaray.stub.data to org.hibernate.orm.core;
-                            // Rules for DI Components
-                            opens io.john.amiscaray.domain to quak.framework.core;
-                            opens io.john.amiscaray.quak.data.di to quak.framework.core;
-                            
-                            requires quak.framework.core;
-                            requires quak.framework.data;
-                            requires quak.framework.generator.model;
-                            requires quak.framework.web;
-                            requires quak.framework.web.model;
-                            requires jakarta.persistence;
-                            requires static lombok;
-                            requires org.reflections;
+                             requires org.slf4j;
+                         
+                             // GENERATED SOURCES:
+                             exports io.john.amiscaray.http to quak.framework.core, quak.framework.web;
+                            \s
+                             opens io.john.amiscaray.stub.model to com.fasterxml.jackson.databind;
+                             opens io.john.amiscaray.quak.data.di to quak.framework.core;
+                             opens io.john.amiscaray.domain to quak.framework.core;
+                             opens io.john.amiscaray.stub.data to org.hibernate.orm.core;
+                            \s
+                             requires quak.framework.core;
+                             requires quak.framework.data;
+                             requires quak.framework.generator.model;
+                             requires quak.framework.web;
+                             requires quak.framework.web.model;
+                             requires jakarta.persistence;
+                             requires static lombok;
+                             requires org.reflections;
                         }
                         """)
         );


### PR DESCRIPTION
- Fixes problem with duplicate opens statements when entities and DTOs are in the same package.
- Fixes problem with targetControllerPackage not being used in export statement.
- Renames targetPackage mojo param to targetControllerPackage.


This fixes #131.